### PR TITLE
Update redux-store.html to support REDUX DEV TOOLS Chrome extesion

### DIFF
--- a/ep62-redux-async/redux-store.html
+++ b/ep62-redux-async/redux-store.html
@@ -37,8 +37,10 @@
   }
   const store = Redux.createStore(
     reducer,
-    Redux.applyMiddleware(ReduxThunk.default)
-  );
+    Redux.compose(
+    Redux.applyMiddleware(ReduxThunk.default),
+    window.devToolsExtension && window.devToolsExtension()
+  ));
   const ReduxBehavior = PolymerRedux(store);
   const AsyncActionsBehavior = {
     actions: {


### PR DESCRIPTION
I suggest to add support for REDUX dev tool extension used in Chrome, is very handy to have a panel which shows the timeline of changes in your state, to do that you need to use " window.devToolsExtension() or window.__REDUX_DEVTOOLS_EXTENSION__" and Redux.compose().

const store = Redux.createStore(
reducer,
Redux.compose(
Redux.applyMiddleware(ReduxThunk.default),
window.devToolsExtension && window.devToolsExtension()
));